### PR TITLE
Add web manifest for GenPwd Pro PWA

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,55 @@
+# Déploiement de GenPwd Pro PWA
+
+Ce document détaille les étapes à suivre avant, pendant et après le déploiement de la Progressive Web App GenPwd Pro.
+
+## 1. Checklist pré-déploiement
+
+- [ ] Exécuter `npm install` pour s'assurer que toutes les dépendances sont à jour.
+- [ ] Lancer `npm run icons:generate` pour régénérer les icônes PWA.
+- [ ] Construire la PWA avec `npm run pwa:build` et vérifier que `dist/pwa/` contient les fichiers attendus.
+- [ ] Examiner le rapport de build généré dans `dist/pwa/pwa-build-report.json`.
+- [ ] Tester le fonctionnement hors ligne via `npm run pwa:test` et `tests/test-pwa.html`.
+- [ ] Mettre à jour le numéro de version et la note de version dans `CHANGELOG.md` si nécessaire.
+
+## 2. Configuration serveur
+
+Pour garantir une expérience PWA optimale :
+
+- Servez la PWA depuis un domaine HTTPS avec un certificat TLS valide.
+- Configurez les en-têtes HTTP suivants :
+  - `Service-Worker-Allowed: /` pour autoriser le scope racine.
+  - `Cache-Control: public, max-age=31536000, immutable` pour les assets fingerprintés (icônes, CSS/JS versionnés).
+  - `Content-Security-Policy` permettant le chargement des scripts et styles utilisés par GenPwd Pro.
+- Activez la compression (Gzip ou Brotli) pour les fichiers statiques (`.html`, `.css`, `.js`, `.json`).
+- Vérifiez que `manifest.json` et `service-worker.js` sont servis avec le type MIME approprié (`application/json`, `text/javascript`).
+
+## 3. Déploiement
+
+1. Nettoyez le dossier de destination sur le serveur ou le CDN.
+2. Transférez l'intégralité de `dist/pwa/` en conservant l'arborescence.
+3. Invalidez le cache CDN si nécessaire pour diffuser la nouvelle version.
+4. Vérifiez que `https://votre-domaine/manifest.json` et `https://votre-domaine/service-worker.js` sont accessibles.
+
+## 4. Tests d'installation
+
+- **Mobile (Android / Chrome, Firefox)** : Ouvrez l'URL, attendez la bannière d'installation puis installez. Vérifiez le lancement hors ligne.
+- **iOS (Safari 16+)** : Ajoutez la PWA à l'écran d'accueil via le menu de partage, testez le lancement hors ligne.
+- **Desktop (Chrome, Edge)** : Utilisez le bouton d'installation ou l'icône "Installer" dans la barre d'adresse, puis testez les raccourcis et l'état offline.
+
+## 5. Debugging PWA
+
+- Ouvrez Chrome DevTools > Application > Service Workers pour surveiller l'état d'enregistrement, forcer la mise à jour et inspecter les caches.
+- Utilisez l'onglet Application > Manifest pour vérifier les métadonnées, icônes et critères d'installation.
+- L'onglet Lighthouse permet d'exécuter un audit PWA, mesurant la performance et l'installabilité.
+- En cas de problème d'installation, vérifiez la console JavaScript et les logs du service worker (`chrome://serviceworker-internals`).
+
+## 6. Métriques de performance
+
+Surveillez les indicateurs suivants après le déploiement :
+
+- **Largest Contentful Paint (LCP)** et **First Input Delay (FID)** pour la réactivité.
+- **Core Web Vitals** via Google Search Console ou PageSpeed Insights.
+- **Taille du bundle** (`dist/pwa/`) et poids du cache pour s'assurer que la PWA reste légère.
+- **Taux d'installation** et **rétention hors ligne** si vous collectez des métriques analytiques consenties.
+
+Ces étapes garantissent que GenPwd Pro fournit une expérience PWA fiable et performante sur l'ensemble des plateformes.

--- a/README-PWA.md
+++ b/README-PWA.md
@@ -1,0 +1,52 @@
+# GenPwd Pro PWA Guide
+
+Ce guide présente les commandes essentielles pour travailler avec la Progressive Web App de GenPwd Pro v2.5.1.
+
+## Générer les icônes
+
+```bash
+npm run icons:generate
+```
+
+Cette commande s'appuie sur `tools/generate-icons.js` pour créer un SVG de base "GP" puis exporter toutes les tailles d'icônes requises (72×72 à 512×512) dans `src/assets/icons/`.
+
+## Builder la PWA
+
+```bash
+npm run pwa:build
+```
+
+Le script `tools/build-pwa.js` régénère les icônes, copie les ressources nécessaires dans `dist/pwa/`, vérifie la présence des fichiers critiques (`index.html`, `manifest.json`, `service-worker.js`, dictionnaires, assets) et génère un rapport de build.
+
+## Tester localement
+
+```bash
+npm run pwa:test
+```
+
+Cette commande exécute le build puis sert la PWA depuis `dist/pwa/` grâce à `http-server` sur `http://localhost:8080`. Ouvrez ce lien dans votre navigateur et utilisez la page `tests/test-pwa.html` pour diagnostiquer l'enregistrement du service worker, le cache et les scénarios d'installation.
+
+## Déployer en production
+
+```bash
+npm run pwa:deploy
+```
+
+Le script prépare la sortie dans `dist/pwa/` et rappelle de déployer ce contenu sur un serveur HTTPS. Copiez l'intégralité du dossier sur votre infrastructure de production (CDN, hébergement statique ou serveur web) en conservant la même arborescence.
+
+## Tester l'installation PWA
+
+1. Ouvrez la PWA dans un navigateur compatible (Chrome, Edge, Firefox pour Android, Safari iOS 16+).
+2. Vérifiez que le service worker est actif via la bannière ou la console DevTools.
+3. Utilisez le bouton "Installer l'app" injecté par `pwa-installer.js` ou l'option "Installer" du navigateur.
+4. Confirmez que l'application installée démarre en mode standalone et que les raccourcis (`/?mode=syllables`, `/?mode=passphrase`) fonctionnent hors ligne.
+
+## Prérequis HTTPS
+
+Les PWA exigent un contexte sécurisé. Assurez-vous que :
+
+- Le domaine de production sert toutes les pages via HTTPS avec un certificat valide.
+- Les ressources tierces (APIs, polices, images) sont également disponibles en HTTPS.
+- Les en-têtes `Service-Worker-Allowed` ou `Content-Security-Policy` ne bloquent pas `service-worker.js`.
+
+En environnement local, `http-server` utilise HTTP simple ; c'est acceptable pour le développement tant que vous testez les fonctionnalités d'installation sur `localhost` ou via `chrome://flags/#unsafely-treat-insecure-origin-as-secure` si nécessaire.

--- a/package.json
+++ b/package.json
@@ -12,12 +12,17 @@
     "test:watch": "nodemon --watch src --watch tools --exec 'npm run test'",
     "lint": "eslint src/js/**/*.js tools/**/*.js",
     "clean": "rimraf dist/*",
-    "start": "npm run dev"
+    "start": "npm run dev",
+    "icons:generate": "node tools/generate-icons.js",
+    "pwa:build": "node tools/build-pwa.js",
+    "pwa:test": "npm run pwa:build && npx http-server dist/pwa -p 8080",
+    "pwa:deploy": "npm run pwa:build && echo 'Déployez le contenu de dist/pwa/ sur votre serveur HTTPS'"
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
     "chokidar": "^3.5.3",
-    "puppeteer": "^21.6.1",
+    "puppeteer": "^21.0.0",
+    "http-server": "^14.1.1",
     "eslint": "^8.56.0",
     "nodemon": "^3.0.2"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,18 @@
   <link rel="stylesheet" href="styles/components.css">
   <link rel="stylesheet" href="styles/layout.css">
   <link rel="stylesheet" href="styles/modal.css">
+  <link rel="stylesheet" href="styles/pwa-styles.css">
+
+  <!-- Métadonnées PWA -->
+  <link rel="manifest" href="manifest.json">
+  <meta name="application-name" content="GenPwd Pro">
+  <meta name="theme-color" content="#2563eb">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="GenPwd Pro">
+  <link rel="apple-touch-icon" sizes="192x192" href="assets/icons/icon-192x192.png">
+  <link rel="apple-touch-icon" sizes="512x512" href="assets/icons/icon-512x512.png">
   
   <!-- Styles pour les tests -->
   <style>
@@ -509,7 +521,10 @@
 
   <!-- JavaScript modulaire ES6 -->
   <script type="module" src="js/app.js"></script>
-  
+
+  <!-- Intégration PWA -->
+  <script src="pwa-installer.js" defer></script>
+
   <!-- Intégration UI des tests -->
   <script>
   document.addEventListener('DOMContentLoaded', function() {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "description": "Générateur de mots de passe et passphrases sécurisé, modes syllabes et passphrase.",
   "lang": "fr",
   "start_url": "/",
-  "scope": "./",
+  "scope": "/",
   "display": "standalone",
   "orientation": "portrait-primary",
   "background_color": "#0f172a",
@@ -65,7 +65,7 @@
       "name": "Mode Syllabes",
       "short_name": "Syllabes",
       "description": "Générer des mots de passe basés sur des syllabes.",
-      "url": "./index.html?mode=syllables",
+      "url": "/?mode=syllables",
       "icons": [
         {
           "src": "assets/icons/icon-192x192.png",
@@ -78,7 +78,7 @@
       "name": "Mode Passphrase",
       "short_name": "Passphrase",
       "description": "Créer des passphrases sécurisées à partir du dictionnaire.",
-      "url": "./index.html?mode=passphrase",
+      "url": "/?mode=passphrase",
       "icons": [
         {
           "src": "assets/icons/icon-192x192.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,85 @@
+{
+  "name": "GenPwd Pro",
+  "short_name": "GenPwd",
+  "version": "2.5.1",
+  "description": "Générateur de mots de passe et passphrases sécurisé, modes syllabes et passphrase.",
+  "lang": "fr",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#2563eb",
+  "icons": [
+    {
+      "src": "icons/icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-128x128.png",
+      "sizes": "128x128",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-152x152.png",
+      "sizes": "152x152",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-384x384.png",
+      "sizes": "384x384",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Mode Syllabes",
+      "short_name": "Syllabes",
+      "description": "Générer des mots de passe basés sur des syllabes.",
+      "url": "./index.html?mode=syllables",
+      "icons": [
+        {
+          "src": "icons/icon-192x192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        }
+      ]
+    },
+    {
+      "name": "Mode Passphrase",
+      "short_name": "Passphrase",
+      "description": "Créer des passphrases sécurisées à partir du dictionnaire.",
+      "url": "./index.html?mode=passphrase",
+      "icons": [
+        {
+          "src": "icons/icon-192x192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        }
+      ]
+    }
+  ]
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,51 +4,57 @@
   "version": "2.5.1",
   "description": "Générateur de mots de passe et passphrases sécurisé, modes syllabes et passphrase.",
   "lang": "fr",
-  "start_url": "./index.html",
+  "start_url": "/",
   "scope": "./",
   "display": "standalone",
+  "orientation": "portrait-primary",
   "background_color": "#0f172a",
   "theme_color": "#2563eb",
+  "categories": [
+    "security",
+    "utilities",
+    "productivity"
+  ],
   "icons": [
     {
-      "src": "icons/icon-72x72.png",
+      "src": "assets/icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png"
     },
     {
-      "src": "icons/icon-96x96.png",
+      "src": "assets/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "icons/icon-128x128.png",
+      "src": "assets/icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png"
     },
     {
-      "src": "icons/icon-144x144.png",
+      "src": "assets/icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "icons/icon-152x152.png",
+      "src": "assets/icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png"
     },
     {
-      "src": "icons/icon-192x192.png",
+      "src": "assets/icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "icons/icon-384x384.png",
+      "src": "assets/icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "icons/icon-512x512.png",
+      "src": "assets/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
@@ -62,7 +68,7 @@
       "url": "./index.html?mode=syllables",
       "icons": [
         {
-          "src": "icons/icon-192x192.png",
+          "src": "assets/icons/icon-192x192.png",
           "sizes": "192x192",
           "type": "image/png"
         }
@@ -75,7 +81,7 @@
       "url": "./index.html?mode=passphrase",
       "icons": [
         {
-          "src": "icons/icon-192x192.png",
+          "src": "assets/icons/icon-192x192.png",
           "sizes": "192x192",
           "type": "image/png"
         }

--- a/src/pwa-installer.js
+++ b/src/pwa-installer.js
@@ -1,0 +1,173 @@
+import { showToast } from './js/utils/toast.js';
+
+const SW_PATH = '/service-worker.js';
+const INSTALL_BUTTON_ID = 'install-app-button';
+const PWA_READY_KEY = 'genpwd-pro:pwa-ready';
+
+let deferredPrompt = null;
+let installButton = null;
+let isControllerChanging = false;
+
+function init() {
+  if (!('serviceWorker' in navigator)) {
+    console.warn('[PWA] Service workers non supportés');
+    return;
+  }
+
+  prepareInstallButton();
+  registerServiceWorker();
+  listenToBeforeInstallPrompt();
+  listenToAppInstalled();
+}
+
+function prepareInstallButton() {
+  installButton = document.getElementById(INSTALL_BUTTON_ID);
+
+  if (!installButton) {
+    installButton = document.createElement('button');
+    installButton.id = INSTALL_BUTTON_ID;
+    installButton.type = 'button';
+    installButton.className = 'btn ghost';
+    installButton.style.display = 'none';
+    installButton.innerText = '📥 Installer l\'app';
+
+    const headerRight = document.querySelector('.header-right');
+    if (headerRight) {
+      headerRight.appendChild(installButton);
+    } else {
+      document.body.appendChild(installButton);
+    }
+  }
+
+  installButton.addEventListener('click', handleInstallClick);
+}
+
+function handleInstallClick() {
+  if (!deferredPrompt) {
+    showToast('Installation impossible pour le moment.', 'error');
+    return;
+  }
+
+  installButton.disabled = true;
+
+  deferredPrompt.prompt();
+  deferredPrompt.userChoice
+    .then(({ outcome }) => {
+      if (outcome === 'accepted') {
+        showToast('Installation de GenPwd Pro…', 'success');
+        hideInstallButton();
+      } else {
+        showToast('Installation annulée.', 'info');
+        // Autoriser un nouvel essai si un nouvel événement est déclenché
+        installButton.style.display = 'inline-flex';
+      }
+    })
+    .catch((error) => {
+      console.error('[PWA] Erreur lors de l\'installation', error);
+      showToast('Impossible de lancer l\'installation.', 'error');
+    })
+    .finally(() => {
+      deferredPrompt = null;
+      installButton.disabled = false;
+    });
+}
+
+function listenToBeforeInstallPrompt() {
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+
+    if (!isStandalone()) {
+      installButton.style.display = 'inline-flex';
+      showToast('Installez GenPwd Pro pour un accès rapide hors ligne.', 'info');
+    }
+  });
+}
+
+function listenToAppInstalled() {
+  window.addEventListener('appinstalled', () => {
+    showToast('GenPwd Pro est installée sur cet appareil.', 'success');
+    hideInstallButton();
+  });
+}
+
+function hideInstallButton() {
+  if (installButton) {
+    installButton.style.display = 'none';
+  }
+}
+
+function isStandalone() {
+  return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+}
+
+async function registerServiceWorker() {
+  try {
+    const registration = await navigator.serviceWorker.register(SW_PATH, { scope: '/' });
+    monitorServiceWorkerUpdates(registration);
+
+    if (!localStorage.getItem(PWA_READY_KEY)) {
+      showToast('Mode hors ligne prêt ✨', 'success');
+      localStorage.setItem(PWA_READY_KEY, '1');
+    }
+
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      if (isControllerChanging) {
+        return;
+      }
+      isControllerChanging = true;
+      showToast('Nouvelle version installée. Rechargement…', 'info');
+      setTimeout(() => window.location.reload(), 800);
+    });
+  } catch (error) {
+    console.error('[PWA] Enregistrement SW échoué', error);
+    showToast('Mode hors ligne indisponible.', 'error');
+  }
+}
+
+function monitorServiceWorkerUpdates(registration) {
+  if (!registration) {
+    return;
+  }
+
+  if (registration.waiting) {
+    notifyAboutUpdate(registration.waiting);
+  }
+
+  registration.addEventListener('updatefound', () => {
+    const newWorker = registration.installing;
+    if (!newWorker) {
+      return;
+    }
+
+    newWorker.addEventListener('statechange', () => {
+      if (newWorker.state === 'installed') {
+        if (navigator.serviceWorker.controller) {
+          notifyAboutUpdate(registration.waiting || newWorker);
+        } else {
+          showToast('GenPwd Pro est prête à fonctionner hors ligne.', 'success');
+        }
+      }
+    });
+  });
+}
+
+function notifyAboutUpdate(worker) {
+  if (!worker) {
+    return;
+  }
+
+  const shouldUpdate = window.confirm('Une nouvelle version de GenPwd Pro est disponible. L\'installer maintenant ?');
+  if (shouldUpdate) {
+    worker.postMessage({ type: 'SKIP_WAITING' });
+  } else {
+    showToast('Mise à jour reportée. Pensez à recharger plus tard.', 'info');
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
+

--- a/src/pwa-installer.js
+++ b/src/pwa-installer.js
@@ -1,8 +1,8 @@
-import { showToast } from './js/utils/toast.js';
-
 const SW_PATH = '/service-worker.js';
 const INSTALL_BUTTON_ID = 'install-app-button';
 const PWA_READY_KEY = 'genpwd-pro:pwa-ready';
+const TOAST_CONTAINER_ID = 'pwa-toast-container';
+const TOAST_DURATION = 4000;
 
 let deferredPrompt = null;
 let installButton = null;
@@ -18,6 +18,41 @@ function init() {
   registerServiceWorker();
   listenToBeforeInstallPrompt();
   listenToAppInstalled();
+}
+
+function showToast(message, type = 'info') {
+  const container = getToastContainer();
+  const toast = document.createElement('div');
+  toast.className = `pwa-toast pwa-toast--${type}`;
+  toast.setAttribute('role', 'status');
+  toast.setAttribute('aria-live', 'polite');
+  toast.textContent = message;
+
+  container.appendChild(toast);
+
+  requestAnimationFrame(() => {
+    toast.classList.add('is-visible');
+  });
+
+  setTimeout(() => {
+    toast.classList.remove('is-visible');
+    toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+  }, TOAST_DURATION);
+}
+
+function getToastContainer() {
+  let container = document.getElementById(TOAST_CONTAINER_ID);
+
+  if (!container) {
+    container = document.createElement('div');
+    container.id = TOAST_CONTAINER_ID;
+    container.className = 'pwa-toast-container';
+    container.setAttribute('aria-live', 'polite');
+    container.setAttribute('aria-atomic', 'true');
+    document.body.appendChild(container);
+  }
+
+  return container;
 }
 
 function prepareInstallButton() {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,88 @@
+const CACHE_NAME = 'genpwd-pro-v2.5.1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/styles/main.css',
+  '/styles/layout.css',
+  '/styles/components.css',
+  '/styles/modal.css',
+  '/js/app.js',
+  '/dictionaries/english.json',
+  '/dictionaries/french.json',
+  '/dictionaries/latin.json',
+  '/assets/icons/icon-72x72.png',
+  '/assets/icons/icon-96x96.png',
+  '/assets/icons/icon-128x128.png',
+  '/assets/icons/icon-144x144.png',
+  '/assets/icons/icon-152x152.png',
+  '/assets/icons/icon-192x192.png',
+  '/assets/icons/icon-384x384.png',
+  '/assets/icons/icon-512x512.png'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_CACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+          return undefined;
+        })
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestURL = new URL(event.request.url);
+  if (requestURL.origin !== self.location.origin) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((networkResponse) => {
+          if (
+            !networkResponse ||
+            networkResponse.status !== 200 ||
+            networkResponse.type === 'opaque'
+          ) {
+            return networkResponse;
+          }
+
+          const responseClone = networkResponse.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(event.request, responseClone);
+          });
+
+          return networkResponse;
+        })
+        .catch(() => {
+          if (event.request.mode === 'navigate') {
+            return caches.match('/index.html');
+          }
+          return caches.match(event.request);
+        });
+    })
+  );
+});

--- a/src/styles/pwa-styles.css
+++ b/src/styles/pwa-styles.css
@@ -1,0 +1,114 @@
+:root {
+  --pwa-accent: #2563eb;
+  --pwa-accent-dark: #1d4ed8;
+  --pwa-surface: rgba(15, 23, 42, 0.9);
+  --pwa-border: rgba(148, 163, 184, 0.25);
+  --pwa-text: #e2e8f0;
+}
+
+#install-app-button {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid var(--pwa-accent);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.2), rgba(59, 130, 246, 0.1));
+  color: var(--pwa-text);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+}
+
+#install-app-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.35);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.3), rgba(59, 130, 246, 0.2));
+}
+
+#install-app-button:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.2);
+}
+
+#install-app-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.pwa-toast-container {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 9999;
+}
+
+.pwa-toast {
+  min-width: 260px;
+  max-width: min(320px, calc(100vw - 3rem));
+  padding: 0.9rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid var(--pwa-border);
+  background: var(--pwa-surface);
+  color: var(--pwa-text);
+  font-size: 0.95rem;
+  line-height: 1.3;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.pwa-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.pwa-toast--info {
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.pwa-toast--success {
+  border-color: rgba(16, 185, 129, 0.45);
+  background: rgba(16, 185, 129, 0.12);
+}
+
+.pwa-toast--error {
+  border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(239, 68, 68, 0.12);
+}
+
+@media (max-width: 960px) {
+  #install-app-button {
+    padding: 0.55rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .pwa-toast-container {
+    inset: auto 1rem 1rem 1rem;
+  }
+
+  .pwa-toast {
+    max-width: 100%;
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  #install-app-button {
+    width: 100%;
+    justify-content: center;
+    margin-top: 0.75rem;
+  }
+
+  .pwa-toast-container {
+    inset: auto 0.75rem 0.75rem 0.75rem;
+  }
+}

--- a/src/tests/test-pwa.html
+++ b/src/tests/test-pwa.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GenPwd Pro – Console PWA</title>
+    <link rel="stylesheet" href="../styles/pwa-styles.css" />
+    <style>
+      :root {
+        color-scheme: dark light;
+      }
+      body {
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        padding: 1.5rem 2rem;
+        background: rgba(15, 23, 42, 0.85);
+        backdrop-filter: blur(18px);
+        border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      main {
+        flex: 1;
+        padding: 2rem;
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      section {
+        background: rgba(30, 41, 59, 0.85);
+        border-radius: 1.25rem;
+        padding: 1.5rem;
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+        border: 1px solid rgba(148, 163, 184, 0.16);
+      }
+      h1, h2 {
+        margin: 0 0 1rem;
+        font-weight: 700;
+        color: #f8fafc;
+      }
+      p {
+        margin: 0 0 0.75rem;
+        line-height: 1.6;
+      }
+      .status {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+      }
+      .status span {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .status span strong {
+        color: #38bdf8;
+      }
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 999px;
+        padding: 0.65rem 1.5rem;
+        font-weight: 600;
+        cursor: pointer;
+        color: #0f172a;
+        background: linear-gradient(135deg, #38bdf8, #2563eb);
+        box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 30px rgba(37, 99, 235, 0.4);
+      }
+      button:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+      ul {
+        padding-left: 1.25rem;
+        margin: 0;
+        display: grid;
+        gap: 0.35rem;
+      }
+      .log {
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 0.75rem;
+        padding: 1rem;
+        font-family: "Fira Code", "Consolas", monospace;
+        font-size: 0.85rem;
+        line-height: 1.5;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        max-height: 200px;
+        overflow-y: auto;
+      }
+      footer {
+        padding: 1rem 2rem;
+        font-size: 0.85rem;
+        text-align: center;
+        color: rgba(148, 163, 184, 0.7);
+      }
+      @media (max-width: 640px) {
+        header, main, footer {
+          padding-left: 1.25rem;
+          padding-right: 1.25rem;
+        }
+        main {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Console PWA – GenPwd Pro</h1>
+      <p>Utilisez cet espace pour vérifier rapidement le fonctionnement hors ligne et l'état d'installation.</p>
+    </header>
+    <main>
+      <section>
+        <h2>Statuts</h2>
+        <div class="status">
+          <span><strong>Service worker :</strong> <span id="sw-status">–</span></span>
+          <span><strong>Cache :</strong> <span id="cache-status">–</span></span>
+          <span><strong>Mode installation :</strong> <span id="install-status">–</span></span>
+        </div>
+      </section>
+      <section>
+        <h2>Actions rapides</h2>
+        <div class="status">
+          <button id="btn-register">Enregistrer le service worker</button>
+          <button id="btn-unregister">Désenregistrer le service worker</button>
+          <button id="btn-check-cache">Analyser le cache</button>
+          <button id="btn-simulate-install">Simuler l'invite d'installation</button>
+          <button id="btn-simulate-update">Simuler une mise à jour</button>
+        </div>
+      </section>
+      <section>
+        <h2>Détails du cache</h2>
+        <ul id="cache-details"></ul>
+      </section>
+      <section>
+        <h2>Journal</h2>
+        <div class="log" id="log"></div>
+      </section>
+    </main>
+    <footer>GenPwd Pro v2.5.1 · Tests PWA</footer>
+
+    <script>
+      const logContainer = document.getElementById('log');
+      const swStatus = document.getElementById('sw-status');
+      const cacheStatus = document.getElementById('cache-status');
+      const installStatus = document.getElementById('install-status');
+      const cacheDetails = document.getElementById('cache-details');
+
+      const essentialAssets = [
+        '/',
+        '/index.html',
+        '/manifest.json',
+        '/pwa-installer.js',
+        '/service-worker.js',
+        '/styles/pwa-styles.css',
+      ];
+
+      function log(message) {
+        const time = new Date().toLocaleTimeString();
+        logContainer.innerText += `[${time}] ${message}\n`;
+        logContainer.scrollTop = logContainer.scrollHeight;
+      }
+
+      function updateInstallStatus() {
+        const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+        installStatus.innerText = isStandalone ? 'Installée (standalone)' : 'Navigateur';
+      }
+
+      async function refreshSwStatus() {
+        if (!('serviceWorker' in navigator)) {
+          swStatus.innerText = 'Non supporté';
+          return;
+        }
+
+        const registration = await navigator.serviceWorker.getRegistration();
+        if (registration) {
+          const state = registration.active ? registration.active.state : 'en attente';
+          swStatus.innerText = `Actif (${state})`;
+        } else {
+          swStatus.innerText = 'Non enregistré';
+        }
+      }
+
+      async function analyseCache() {
+        if (!('caches' in window)) {
+          cacheStatus.innerText = 'Cache API non supportée';
+          log("Cache Storage n'est pas disponible dans ce navigateur.");
+          return;
+        }
+
+        const cacheName = 'genpwd-pro-v2.5.1';
+        const cache = await caches.open(cacheName);
+        cacheDetails.innerHTML = '';
+
+        let cachedCount = 0;
+        for (const asset of essentialAssets) {
+          const match = await cache.match(asset);
+          const li = document.createElement('li');
+          if (match) {
+            li.textContent = `✅ ${asset}`;
+            cachedCount += 1;
+          } else {
+            li.textContent = `⚠️ ${asset} manquant`;
+          }
+          cacheDetails.appendChild(li);
+        }
+
+        cacheStatus.innerText = `${cachedCount}/${essentialAssets.length} ressources`; 
+        log(`Analyse du cache terminée (${cachedCount} ressources trouvées).`);
+      }
+
+      async function registerSw() {
+        if (!('serviceWorker' in navigator)) {
+          log('Les service workers ne sont pas supportés.');
+          return;
+        }
+
+        try {
+          const registration = await navigator.serviceWorker.register('/service-worker.js');
+          log('Service worker enregistré.');
+          swStatus.innerText = 'Actif (enregistrement en cours)';
+          registration.addEventListener('updatefound', () => log('Nouvelle version de service worker détectée.'));
+        } catch (error) {
+          log(`Erreur lors de l\'enregistrement : ${error.message}`);
+        }
+      }
+
+      async function unregisterSw() {
+        const registration = await navigator.serviceWorker.getRegistration();
+        if (!registration) {
+          log('Aucun service worker enregistré.');
+          return;
+        }
+        await registration.unregister();
+        swStatus.innerText = 'Non enregistré';
+        log('Service worker désenregistré.');
+      }
+
+      async function simulateInstall() {
+        log("Simulation d'invite d'installation envoyée.");
+        const event = new CustomEvent('pwa:test-install');
+        window.dispatchEvent(event);
+      }
+
+      async function simulateUpdate() {
+        const registration = await navigator.serviceWorker.getRegistration();
+        if (!registration) {
+          log('Aucun service worker pour simuler la mise à jour.');
+          return;
+        }
+
+        if (registration.waiting) {
+          registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+          log('Message SKIP_WAITING envoyé au worker en attente.');
+        } else {
+          await registration.update();
+          log('Mise à jour du service worker demandée.');
+        }
+      }
+
+      document.getElementById('btn-register').addEventListener('click', registerSw);
+      document.getElementById('btn-unregister').addEventListener('click', unregisterSw);
+      document.getElementById('btn-check-cache').addEventListener('click', analyseCache);
+      document.getElementById('btn-simulate-install').addEventListener('click', simulateInstall);
+      document.getElementById('btn-simulate-update').addEventListener('click', simulateUpdate);
+
+      window.addEventListener('load', () => {
+        updateInstallStatus();
+        refreshSwStatus();
+        analyseCache();
+      });
+
+      window.matchMedia('(display-mode: standalone)').addEventListener('change', updateInstallStatus);
+
+      log('Console PWA initialisée.');
+    </script>
+  </body>
+</html>

--- a/tools/build-pwa.js
+++ b/tools/build-pwa.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+/**
+ * Script de build PWA pour GenPwd Pro.
+ * - Génére les icônes (via generate-icons.js).
+ * - Copie les fichiers nécessaires dans dist/pwa.
+ * - Vérifie la présence des fichiers critiques.
+ * - Produit un rapport de build.
+ */
+
+const fs = require('fs/promises');
+const path = require('path');
+const { generateIcons, ICON_SIZES } = require('./generate-icons');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const SRC_DIR = path.join(ROOT_DIR, 'src');
+const DIST_DIR = path.join(ROOT_DIR, 'dist', 'pwa');
+const REPORT_FILE = path.join(DIST_DIR, 'build-report.json');
+
+const REQUIRED_FILES = [
+  'index.html',
+  'manifest.json',
+  'service-worker.js',
+  'pwa-installer.js',
+  path.join('styles', 'pwa-styles.css'),
+];
+
+const REQUIRED_DIRS = [
+  'js',
+  'styles',
+  'dictionaries',
+  path.join('assets', 'icons'),
+];
+
+async function resetDistDir() {
+  await fs.rm(DIST_DIR, { recursive: true, force: true });
+  await fs.mkdir(DIST_DIR, { recursive: true });
+}
+
+async function copyEntry(source, destination, copiedFiles) {
+  const stats = await fs.stat(source);
+  if (stats.isDirectory()) {
+    await fs.mkdir(destination, { recursive: true });
+    const entries = await fs.readdir(source);
+    for (const entry of entries) {
+      await copyEntry(path.join(source, entry), path.join(destination, entry), copiedFiles);
+    }
+  } else {
+    await fs.copyFile(source, destination);
+    copiedFiles.push(path.relative(ROOT_DIR, destination));
+  }
+}
+
+async function copySources() {
+  const copiedFiles = [];
+  await copyEntry(SRC_DIR, DIST_DIR, copiedFiles);
+  return copiedFiles;
+}
+
+async function validateDist() {
+  const missing = [];
+
+  for (const file of REQUIRED_FILES) {
+    const filePath = path.join(DIST_DIR, file);
+    try {
+      await fs.access(filePath);
+    } catch (error) {
+      missing.push(path.relative(ROOT_DIR, filePath));
+    }
+  }
+
+  for (const dir of REQUIRED_DIRS) {
+    const dirPath = path.join(DIST_DIR, dir);
+    try {
+      const stats = await fs.stat(dirPath);
+      if (!stats.isDirectory()) {
+        missing.push(path.relative(ROOT_DIR, dirPath));
+      }
+    } catch (error) {
+      missing.push(path.relative(ROOT_DIR, dirPath));
+    }
+  }
+
+  for (const size of ICON_SIZES) {
+    const iconPath = path.join(DIST_DIR, 'assets', 'icons', `icon-${size}x${size}.png`);
+    try {
+      await fs.access(iconPath);
+    } catch (error) {
+      missing.push(path.relative(ROOT_DIR, iconPath));
+    }
+  }
+
+  return missing;
+}
+
+async function createReport({ copiedFiles, iconResult, missing }) {
+  const report = {
+    generatedAt: new Date().toISOString(),
+    distDir: path.relative(ROOT_DIR, DIST_DIR),
+    totalFiles: copiedFiles.length,
+    icons: iconResult.generatedFiles.map((entry) => ({
+      size: entry.size,
+      file: path.relative(ROOT_DIR, entry.filePath),
+    })),
+    baseSvg: path.relative(ROOT_DIR, iconResult.baseSvgPath),
+    missing,
+    status: missing.length === 0 ? 'success' : 'incomplete',
+  };
+
+  await fs.writeFile(REPORT_FILE, JSON.stringify(report, null, 2), 'utf8');
+  console.log(`📄 Rapport de build disponible : ${path.relative(ROOT_DIR, REPORT_FILE)}`);
+  if (missing.length > 0) {
+    console.warn('⚠️ Des fichiers sont manquants :');
+    missing.forEach((file) => console.warn(`  - ${file}`));
+  } else {
+    console.log('✅ Tous les fichiers requis sont présents.');
+  }
+}
+
+async function buildPwa() {
+  console.log('🚀 Démarrage du build PWA GenPwd Pro...');
+  const iconResult = await generateIcons();
+  await resetDistDir();
+  const copiedFiles = await copySources();
+  const missing = await validateDist();
+  await createReport({ copiedFiles, iconResult, missing });
+  console.log('✨ Build PWA terminé.');
+  return { copiedFiles, iconResult, missing };
+}
+
+if (require.main === module) {
+  buildPwa().catch((error) => {
+    console.error('❌ Échec du build PWA :', error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildPwa,
+};

--- a/tools/generate-icons.js
+++ b/tools/generate-icons.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+/**
+ * Script de génération des icônes PWA pour GenPwd Pro.
+ * - Crée un SVG de base stylisé "GP".
+ * - Utilise Puppeteer pour rasteriser le SVG en PNG aux tailles standard PWA.
+ * - Enregistre les icônes dans le dossier cible (par défaut src/assets/icons).
+ */
+
+const fs = require('fs/promises');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const ICON_SIZES = [72, 96, 128, 144, 152, 192, 384, 512];
+const DEFAULT_OUTPUT_DIR = path.join(__dirname, '..', 'src', 'assets', 'icons');
+const BASE_SVG_NAME = 'genpwd-pro-base.svg';
+
+const BASE_SVG = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="gpGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <filter id="shadow" x="-15%" y="-15%" width="130%" height="130%">
+      <feDropShadow dx="0" dy="10" stdDeviation="20" flood-color="#0f172a" flood-opacity="0.45" />
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="#0f172a" />
+  <rect x="52" y="52" width="408" height="408" rx="96" fill="url(#gpGradient)" filter="url(#shadow)" />
+  <text x="50%" y="54%" text-anchor="middle" font-family="'Segoe UI', 'Inter', sans-serif" font-size="220" font-weight="700" fill="#f8fafc" letter-spacing="-12">
+    GP
+  </text>
+</svg>`;
+
+function buildSizedSvg(size) {
+  return BASE_SVG.replace('<svg', `<svg width="${size}" height="${size}"`);
+}
+
+async function ensureDirectory(targetDir) {
+  await fs.mkdir(targetDir, { recursive: true });
+}
+
+async function writeBaseSvg(targetDir) {
+  const svgPath = path.join(targetDir, BASE_SVG_NAME);
+  await fs.writeFile(svgPath, BASE_SVG, 'utf8');
+  return svgPath;
+}
+
+async function renderSvgToPng({ page, size, targetDir }) {
+  const svgMarkup = buildSizedSvg(size);
+  const html = `<!DOCTYPE html>
+  <html lang="fr">
+    <head>
+      <meta charset="utf-8" />
+      <style>
+        html, body {
+          margin: 0;
+          padding: 0;
+          width: 100%;
+          height: 100%;
+          background: #0f172a;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        svg {
+          display: block;
+        }
+      </style>
+    </head>
+    <body>
+      ${svgMarkup}
+    </body>
+  </html>`;
+
+  await page.setViewport({ width: size, height: size, deviceScaleFactor: 1 });
+  await page.setContent(html, { waitUntil: 'networkidle0' });
+  await page.waitForTimeout(50);
+  const buffer = await page.screenshot({ type: 'png' });
+  const filePath = path.join(targetDir, `icon-${size}x${size}.png`);
+  await fs.writeFile(filePath, buffer);
+  return filePath;
+}
+
+async function generateIcons({ outputDir = DEFAULT_OUTPUT_DIR } = {}) {
+  const absoluteOutput = path.resolve(outputDir);
+  await ensureDirectory(absoluteOutput);
+  const baseSvgPath = await writeBaseSvg(absoluteOutput);
+
+  const browser = await puppeteer.launch({ headless: 'new' });
+  const page = await browser.newPage();
+  const generatedFiles = [];
+
+  try {
+    for (const size of ICON_SIZES) {
+      const filePath = await renderSvgToPng({ page, size, targetDir: absoluteOutput });
+      generatedFiles.push({ size, filePath });
+      console.log(`✅ Icône ${size}x${size} générée : ${path.relative(process.cwd(), filePath)}`);
+    }
+  } finally {
+    await page.close();
+    await browser.close();
+  }
+
+  console.log(`🎨 SVG de base enregistré : ${path.relative(process.cwd(), baseSvgPath)}`);
+
+  return {
+    outputDir: absoluteOutput,
+    baseSvgPath,
+    generatedFiles,
+  };
+}
+
+if (require.main === module) {
+  generateIcons()
+    .then((result) => {
+      console.log(`\n✨ ${result.generatedFiles.length} icônes générées dans ${result.outputDir}`);
+    })
+    .catch((error) => {
+      console.error('❌ Échec de la génération des icônes PWA:', error);
+      process.exitCode = 1;
+    });
+}
+
+module.exports = {
+  generateIcons,
+  ICON_SIZES,
+  BASE_SVG,
+};


### PR DESCRIPTION
## Summary
- add a web app manifest defining GenPwd Pro metadata, theme colors, icons, and shortcuts for core modes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d68f6257e083218252c6cb1ddbbe41