### PR TITLE
fix(android): resolve Kapt compilation error by fixing version incons…

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -54,7 +54,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"
+        kotlinCompilerExtensionVersion = "1.5.10"
     }
 
     packaging {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,7 +2,7 @@
 buildscript {
     extra.apply {
         set("compose_version", "1.5.4")
-        set("kotlin_version", "1.9.10")
+        set("kotlin_version", "1.9.22")
     }
     repositories {
         google()
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.1.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
         classpath("com.google.dagger:hilt-android-gradle-plugin:2.48")
     }
 }
@@ -18,7 +18,7 @@ buildscript {
 plugins {
     id("com.android.application") version "8.1.2" apply false
     id("com.android.library") version "8.1.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
     id("com.google.dagger.hilt.android") version "2.48" apply false
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 # Java version compatibility
-org.gradle.java.home=C:/Program Files/Eclipse Adoptium/jre-17.0.8.7-hotspot
+org.gradle.java.home=C:/Program Files/Eclipse Adoptium/jdk-17.0.16.8-hotspot
 # Specify Java toolchain version
 org.gradle.jvm.version=17
 
@@ -15,3 +15,8 @@ android.enableJetifier=true
 # Kotlin
 kotlin.code.style=official
 kotlin.incremental=true
+
+# Kapt configuration
+kapt.use.worker.api=true
+kapt.include.compile.classpath=false
+kapt.incremental.apt=true


### PR DESCRIPTION
…istencies

Fixed critical configuration issues causing "Could not load module <Error module>" Kapt error:

- Updated Kotlin version from 1.9.10 to 1.9.22 across all build files
  - Root build.gradle.kts: kotlin_version, kotlin-gradle-plugin, and plugin version
  - Ensures consistent Kotlin version throughout the project

- Updated Compose Compiler Extension from 1.5.3 to 1.5.10
  - Required for compatibility with Kotlin 1.9.22
  - Fixes potential compilation errors with Compose

- Fixed gradle.properties to use JDK instead of JRE
  - Changed from jre-17.0.8.7-hotspot to jdk-17.0.16.8-hotspot
  - Kapt requires full JDK (javac) to function properly

- Added essential Kapt configuration properties:
  - kapt.use.worker.api=true (uses Gradle worker API for better performance)
  - kapt.include.compile.classpath=false (avoids classpath issues)
  - kapt.incremental.apt=true (enables incremental annotation processing)

These changes should resolve the Kapt compilation error and allow successful APK builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)