### PR TITLE
fix(cloud-sync): resolve 56+ compilation errors from cloud sync merge

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -127,7 +127,7 @@ dependencies {
     // WorkManager for Auto-Sync
     implementation("androidx.work:work-runtime-ktx:2.9.0")
     implementation("androidx.hilt:hilt-work:1.1.0")
-    kapt("androidx.hilt:hilt-compiler:1.1.0")
+    ksp("androidx.hilt:hilt-compiler:1.1.0")
 
     // Encrypted SharedPreferences for secure credential storage
     implementation("androidx.security:security-crypto:1.1.0-alpha06")

--- a/android/app/src/main/java/com/julien/genpwdpro/data/repository/VaultRepository.kt
+++ b/android/app/src/main/java/com/julien/genpwdpro/data/repository/VaultRepository.kt
@@ -952,7 +952,7 @@ class VaultRepository @Inject constructor(
                     FolderExport(
                         id = folder.id,
                         name = folder.name,
-                        parentId = folder.parentId,
+                        parentId = folder.parentFolderId,
                         icon = folder.icon,
                         color = folder.color,
                         createdAt = folder.createdAt
@@ -1058,8 +1058,8 @@ class VaultRepository @Inject constructor(
                     id = folderExport.id,
                     vaultId = vaultId,
                     name = folderExport.name,
-                    parentId = folderExport.parentId,
-                    icon = folderExport.icon,
+                    parentFolderId = folderExport.parentId,
+                    icon = folderExport.icon ?: "📁",
                     color = folderExport.color,
                     createdAt = folderExport.createdAt
                 )
@@ -1072,7 +1072,7 @@ class VaultRepository @Inject constructor(
                     id = tagExport.id,
                     vaultId = vaultId,
                     name = tagExport.name,
-                    color = tagExport.color,
+                    color = tagExport.color ?: "#808080",
                     createdAt = tagExport.createdAt
                 )
                 tagDao.insert(tag)

--- a/android/app/src/main/java/com/julien/genpwdpro/data/sync/CloudProvider.kt
+++ b/android/app/src/main/java/com/julien/genpwdpro/data/sync/CloudProvider.kt
@@ -84,9 +84,9 @@ interface CloudProvider {
     /**
      * Liste tous les vaults synchronisés
      *
-     * @return Liste des IDs de vaults
+     * @return Liste des métadonnées de fichiers cloud
      */
-    suspend fun listVaults(): List<String>
+    suspend fun listVaults(): List<CloudFileMetadata>
 
     /**
      * Récupère le quota de stockage

--- a/android/app/src/main/java/com/julien/genpwdpro/data/sync/SyncPreferencesManager.kt
+++ b/android/app/src/main/java/com/julien/genpwdpro/data/sync/SyncPreferencesManager.kt
@@ -121,11 +121,11 @@ class SyncPreferencesManager @Inject constructor(
      * Récupère l'intervalle de synchronisation
      */
     fun getSyncInterval(): SyncInterval {
-        val name = configPrefs.getString(KEY_SYNC_INTERVAL, SyncInterval.ONE_HOUR.name)
+        val name = configPrefs.getString(KEY_SYNC_INTERVAL, SyncInterval.HOURLY.name)
         return try {
-            SyncInterval.valueOf(name ?: SyncInterval.ONE_HOUR.name)
+            SyncInterval.valueOf(name ?: SyncInterval.HOURLY.name)
         } catch (e: IllegalArgumentException) {
-            SyncInterval.ONE_HOUR
+            SyncInterval.HOURLY
         }
     }
 

--- a/android/app/src/main/java/com/julien/genpwdpro/data/sync/providers/OneDriveProvider.kt
+++ b/android/app/src/main/java/com/julien/genpwdpro/data/sync/providers/OneDriveProvider.kt
@@ -455,11 +455,12 @@ class OneDriveProvider(
                     val timestamp = parseIso8601(modifiedTime)
 
                     CloudFileMetadata(
-                        id = fileId,
-                        name = name,
+                        fileId = fileId,
+                        fileName = name,
                         size = size,
                         modifiedTime = timestamp,
-                        checksum = null // OneDrive ne fournit pas le checksum facilement
+                        checksum = null,
+                        version = null
                     )
                 }
             }

--- a/android/app/src/main/java/com/julien/genpwdpro/data/sync/providers/PCloudProvider.kt
+++ b/android/app/src/main/java/com/julien/genpwdpro/data/sync/providers/PCloudProvider.kt
@@ -488,11 +488,12 @@ class PCloudProvider(
                     .mapNotNull { content ->
                         content.fileId?.let { fileId ->
                             CloudFileMetadata(
-                                id = fileId.toString(),
-                                name = content.name,
+                                fileId = fileId.toString(),
+                                fileName = content.name,
                                 size = content.size ?: 0,
                                 modifiedTime = parseTimestamp(content.modified),
-                                checksum = null // pCloud ne fournit pas le checksum dans listFolder
+                                checksum = null,
+                                version = null
                             )
                         }
                     }

--- a/android/app/src/main/java/com/julien/genpwdpro/data/sync/providers/ProtonDriveProvider.kt
+++ b/android/app/src/main/java/com/julien/genpwdpro/data/sync/providers/ProtonDriveProvider.kt
@@ -622,11 +622,12 @@ class ProtonDriveProvider(
                     .filter { it.name.endsWith(".enc") }
                     .map { file ->
                         CloudFileMetadata(
-                            id = file.id,
-                            name = file.name,
+                            fileId = file.id,
+                            fileName = file.name,
                             size = file.size,
                             modifiedTime = file.modifyTime * 1000, // Proton utilise secondes
-                            checksum = null
+                            checksum = null,
+                            version = null
                         )
                     }
             } else {


### PR DESCRIPTION
This commit fixes all compilation errors introduced by the cloud sync merge:

✅ Build System:
- build.gradle.kts: Replace kapt with ksp for hilt-compiler (line 130)

✅ Code Corruption:
- OAuthCallbackManager.kt: Recreate file to remove invisible character corruption

✅ Cloud Provider Interface:
- CloudProvider.kt: Change listVaults() return type from List<String> to List<CloudFileMetadata>
- Remove obsolete providerType property from GoogleDriveProvider

✅ Provider Implementations:
- GoogleDriveProvider.kt (providers/): Update listVaults() to return CloudFileMetadata list
- GoogleDriveProvider.kt (data/sync/): Same fix for duplicate file
- OneDriveProvider.kt: Fix CloudFileMetadata constructor (fileId, fileName params)
- PCloudProvider.kt: Fix CloudFileMetadata constructor parameters
- ProtonDriveProvider.kt: Fix CloudFileMetadata constructor parameters

✅ Sync Preferences:
- SyncPreferencesManager.kt: Replace SyncInterval.ONE_HOUR with HOURLY (lines 124-128)

✅ Vault Repository:
- VaultRepository.kt: Fix FolderEntity property name (parentId → parentFolderId)
- VaultRepository.kt: Add null-safety for icon and color in import (lines 955, 1062, 1075)

All changes respect existing architecture and maintain compatibility with:
- Biometric authentication (BiometricHelper.kt)
- Password pre-fill (NavGraph.kt)
- Argon2id encryption (VaultCryptoManager.kt)
- Session management (SessionManager.kt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)