### PR TITLE
feat: surface vault shortcuts and navigation

### DIFF
--- a/android/app/src/main/java/com/julien/genpwdpro/presentation/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/julien/genpwdpro/presentation/navigation/NavGraph.kt
@@ -114,8 +114,8 @@ fun AppNavGraph(
                 onNavigateToVault = { vaultId ->
                     navController.navigate(Screen.UnlockVault.createRoute(vaultId))
                 },
-                onNavigateToCreateVault = {
-                    navController.navigate(Screen.CreateVault.route)
+                onNavigateToVaultManager = {
+                    navController.navigate(Screen.VaultManager.route)
                 },
                 onNavigateToHistory = {
                     navController.navigate(Screen.History.route)


### PR DESCRIPTION
## Summary
- extend the dashboard view model to stream vault registry data for UI consumption
- add a vault overview section on the dashboard with quick unlock/manage actions
- route dashboard management shortcuts to the vault manager screen

## Testing
- ./gradlew lint *(fails: SDK location not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_69008eeb3628832188817b6ca93b58ca